### PR TITLE
Add ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -4,7 +4,7 @@
   "title": "Autumn's Genesis",
   "description": "Dungeon/Quest expansion to CrossCode",
   "repository": "https://github.com/Hsifnus/autumns-genesis",
-  "tags": ["maps", "boss", "character"],
+  "tags": ["maps", "boss", "quests", "player character", "party member"],
   "authors": ["Hsifnus", "ac2pic", "Sandorik00", "elluminance"],
   "dependencies": {
     "item-api": "^0.*",

--- a/ccmod.json
+++ b/ccmod.json
@@ -1,0 +1,15 @@
+{
+  "id": "autumns-genesis",
+  "version": "0.2.6",
+  "title": "Autumn's Genesis",
+  "description": "Dungeon/Quest expansion to CrossCode",
+  "repository": "https://github.com/Hsifnus/autumns-genesis",
+  "tags": ["maps", "boss", "character"],
+  "authors": ["Hsifnus", "ac2pic", "Sandorik00", "elluminance"],
+  "dependencies": {
+    "item-api": "^0.*",
+    "extendable-severed-heads": "^1.0.0",
+    "modifier-api": "^0.1.0"
+  },
+  "prestart": "mod.js"
+}


### PR DESCRIPTION
Hi!
I want to add your mod to a centralized mod repository called CCModDB.
It will allow the upcoming in-game [mod manager](https://github.com/CCDirectLink/CCModManager) to see your mod and make it one-click-installable with all the dependencies. (it's not CCUpdaterUI)
It requires `ccmod.json` to be present.
Please create a new release or update the release `.ccmod` after merging.

You can see the full mod tag list [here](https://github.com/krypciak/CCModDB/blob/ccmodjson/CCMOD-STANDARD.md)
You can change the mod tags as you please, I'm not sure I got everything right